### PR TITLE
Dependency on BH missing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Copyright: file COPYRIGHTS
 License: GPL-3
 Imports: Rcpp (>= 1.0.7), parallel (>= 3.6.2), Matrix, Hotelling, CholWishart, 
           ggplot2, gridExtra (>= 0.9.1), BDgraph, methods, MASS, stats, ess
-LinkingTo: Rcpp, RcppArmadillo, RcppEigen, Matrix, CholWishart
+LinkingTo: Rcpp, RcppArmadillo, RcppEigen, Matrix, CholWishart, BH
 Depends: R (>= 3.5.0)
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
This PR adds `BH` to your package's `LinkingTo` field, so that the `boost` headers can be found when compiling the `DRJ_MCMC_Step.cpp` file. Without this, your package fails to install if the `boost` headers aren't already in the default include paths.

Thanks!